### PR TITLE
Adds error message display logic when comment validation fails

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :set_spot
+  before_action :set_spot, only: [:new, :create, :destroy]
   before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
 
@@ -15,28 +15,21 @@ class CommentsController < ApplicationController
     @comment = Comment.new(comment_params)
     @comment.user = current_user
     @comment.spot = @spot
-    if @comment.save!
+    if @comment.save
       respond_to do |format|
         format.html { redirect_back(fallback_location: root_path) }
         format.js
       end
     else
       respond_to do |format|
-        format.html { render 'events/show' }
+        format.html { render :new }
         format.js
       end
     end
     authorize @comment
   end
 
-   # def destroy
-   #  set_comment
-   #  @comment.destroy
-   #  authorize @comment
-   # end
-
    def destroy
-    set_spot
     set_comment
     @comment.destroy
     authorize @comment

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :spot
-  validates :note, presence: true, allow_blank: false
+  validates :note, presence: true
 end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,15 @@
   <h3>Comments</h3>
   <div class="comments-container">
+
     <%= simple_form_for([@spot_occupied, @comment], remote: true) do |f| %>
+      <% if @comment.errors.any? %>
+          <div class="errors-container">
+        <ul>
+          <% @comment.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      <% end %>
         <div class="comments-form"><%= f.input :note, label: "Leave a comment for tonight's event", as: :text %></div>
         <%= f.submit "Post", class: "btn-dark-transparent"%>
     <% end %>


### PR DESCRIPTION
There are still issues with the redirect is validation fails related to the nested routes that I am trying to figure out. The error message logic in a form partial works effectively as long as the failure is redirected to the partial itself, but that reloads a separate form page —not what we want.